### PR TITLE
Change URL for ManageIQ Design summit website

### DIFF
--- a/2016/ManageIQDesignSummit.yml
+++ b/2016/ManageIQDesignSummit.yml
@@ -6,4 +6,4 @@ description: |
   ManageIQ Design Summit 2016 is a 2-day gathering of open-source cloud management experts and enthusiasts, where the ManageIQ community comes together to share the latest progress and explore future possibilities of the project.
 
   Additional details about the conference, including Call for Papers and registration, are available
-  [on the conference website](https://miqsummit2016.eventbrite.com).
+  [on the conference website](http://manageiq.org/summit/).


### PR DESCRIPTION
Removing Eventbrite link and adding the new summit page on manageiq.org 