### PR TITLE
convert Markdown descriptions to HTML for JSON output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "kwalify"
 gem "json"
+gem "kramdown"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     json (1.8.3)
+    kramdown (1.12.0)
     kwalify (0.7.2)
 
 PLATFORMS
@@ -9,6 +10,7 @@ PLATFORMS
 
 DEPENDENCIES
   json
+  kramdown
   kwalify
 
 BUNDLED WITH

--- a/compile.rb
+++ b/compile.rb
@@ -5,11 +5,57 @@ require 'json'
 require 'fileutils'
 require 'date'
 require 'time'
+require 'kramdown'
 
 @out = 'build/'
 
 upcoming = []
 
+# Convert Markdown to HTML snippet
+def markdownify(text)
+  return if text.nil?
+
+  options = {
+    input: 'GFM',
+    auto_ids: false,
+    hard_wrap: false,
+    header_offset: 2
+  }
+
+  Kramdown::Document.new(text, options)
+                    .to_html
+                    .tr("\n", ' ')
+                    .squeeze(' ')
+                    .strip
+end
+
+# Rewrite conference and talk descriptions as HTML
+def rewrite_descriptions(data)
+  data.each do |_year, confs|
+    next unless confs
+
+    confs.each do |_label, conf|
+      next unless conf.class == Hash
+
+      # Convert Markdown to HTML for conference descriptions
+      if conf['description']
+        conf['description'] = markdownify conf['description']
+      end
+
+      next unless conf['talks']
+
+      conf['talks'].each do |talk|
+        if talk['description']
+          talk['description'] = markdownify talk['description']
+        end
+      end
+    end
+  end
+
+  data
+end
+
+# Check to see the the date is current
 def current?(date_str, time_obj = DateTime.now)
   return false if date_str.nil?
   begin
@@ -19,16 +65,22 @@ def current?(date_str, time_obj = DateTime.now)
   end
 end
 
+# Check the conference to see if it is current
 def current_conf?(conf)
   current?(conf['start']) || current?(conf['end'])
 end
 
+# Output data as YAML, JSON, and JSONP
 def write_files(filename, data)
+  # Rewrite data descriptions as HTML
+  dhtml = rewrite_descriptions(data)
+
   File.write "#{@out}/#{filename}.yml", data.to_yaml
-  File.write "#{@out}/#{filename}.json", data.to_json
-  File.write "#{@out}/#{filename}.jsonp", "parseResponse(#{data.to_json});"
+  File.write "#{@out}/#{filename}.json", dhtml.to_json
+  File.write "#{@out}/#{filename}.jsonp", "parseResponse(#{dhtml.to_json});"
 end
 
+# Load and format data
 def load_data
   events_temp = {}
 
@@ -45,6 +97,9 @@ def load_data
     # Load the conference data, as it is on disk
     conf = YAML.load_file(file)
 
+    # Convert Markdown to HTML for conference descriptions
+    # conf['description'] = markdownify conf['description']
+
     # Ensure every conference has a start and end
     # even if that means we need to look into talks (and infer)
     if conf['talks']
@@ -56,6 +111,12 @@ def load_data
 
       # Might as well sort talks while we're here
       conf['talks'] = conf['talks'].sort_by { |t| t['start'].to_s }
+
+      # Convert Markdown to HTML for each talk
+      # conf['talks'].map do |t|
+        # t['description'] = markdownify t['description']
+        # t
+      # end
     end
 
     # Add (possibly manipulated) conference to events_temp


### PR DESCRIPTION
JSON output now has desciprtions formatted as HTML, for easier inclusion on websites.

(Note: YAML output is still using Markdown for conference & talk descriptions.)