### PR TITLE
Validation improvements, including date checking

### DIFF
--- a/validate.rb
+++ b/validate.rb
@@ -8,7 +8,7 @@ validator = Kwalify::Validator.new(schema)
 
 valid = true
 
-Dir.glob('20*/*.yml').each do |file|
+Dir.glob('20*/*.yml').sort.each do |file|
   begin
     yaml_file = YAML.load_file(file)
     doc = yaml_file

--- a/validate.rb
+++ b/validate.rb
@@ -22,6 +22,27 @@ Dir.glob('20*/*.yml').sort.each do |file|
       end
     end
 
+    if doc['talks']
+      doc['talks'].each do |talk|
+        begin
+          if talk['start']
+            date_type = 'start'
+            DateTime.parse(talk['start'])
+          end
+
+          if talk['end']
+            date_type = 'end'
+            DateTime.parse(talk['start'])
+          end
+
+        rescue StandardError
+          valid = false
+          puts "Error: #{file}: Invalid #{date_type} time: " \
+            "'#{talk[date_type]}' in '#{talk['title']}'"
+        end
+      end
+    end
+
   rescue StandardError => err
     valid = false
 

--- a/validate.rb
+++ b/validate.rb
@@ -8,7 +8,7 @@ validator = Kwalify::Validator.new(schema)
 
 valid = true
 
-Dir.glob('*/*.yml').each do |file|
+Dir.glob('20*/*.yml').each do |file|
   begin
     yaml_file = YAML.load_file(file)
     doc = yaml_file


### PR DESCRIPTION
- only parse directories starting with 20 (for years), so build directory is not included
- sorts the parsing order (so you won't see errors with 2017 and then 2015, if there were errors spanning years)
- use Ruby's DateTime parsing to validate talk datetimes (which should still allow flexibility _AND_ now with a correctness check)