### PR TITLE
Remove "--" from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ employees giving talks at a conference to a Red Hat specific event
 (sponsored event, Internet hangout, IRC session, etc.) to simply having
 a booth or even people representing Red Hat at an event in some manner.
 
---
-
 ## Adding and modifying events
 
 To add or modify conference and talk data, please see:
@@ -19,8 +17,6 @@ https://github.com/OSAS/rh-events/wiki/Adding-and-modifying-events
 If you'd like to learn about the formatting of events, with plenty of
 examples and explanation, read the document on formatting:
   https://github.com/OSAS/rh-events/wiki/Formatting
-
---
 
 ## Validation
 


### PR DESCRIPTION
The "--" characters are supposed to to create a visual separator in
the README.md file, but they seem superfluous, as GitHub's markdown
renders a separator under H1 (#) and H2 (##) headings anyway.

This patch removes these separators, making the README.md file a tad
easier to read.