### PR TITLE
LinuxConNA: fix broken links to conferences

### DIFF
--- a/2013/LinuxCon North America.yml
+++ b/2013/LinuxCon North America.yml
@@ -9,7 +9,7 @@ description: |
   Numerous Red Hat employees will be speaking and attending.
 
   For more details on LinuxCon NA, visit the conference website at
-  <http://events.linuxfoundation.org/events/linuxcon-north-america>.
+  <https://web.archive.org/web/20130916190122/http://events.linuxfoundation.org:80/events/linuxcon-north-america>.
 
 talks:
 

--- a/2014/linuxcon.yml
+++ b/2014/linuxcon.yml
@@ -10,4 +10,4 @@ description: |
 
 
     For more details on LinuxCon, see the LinuxCon website at
-    <http://events.linuxfoundation.org/events/linuxcon-north-america>
+    <https://web.archive.org/web/20140808231115/http://events.linuxfoundation.org:80/events/linuxcon-north-america/

--- a/2015/LinuxConNA.yml
+++ b/2015/LinuxConNA.yml
@@ -11,4 +11,4 @@ description: |
   the Linux platform.   
 
   More information is available at
-  <http://events.linuxfoundation.org/events/linuxcon-north-america>
+  <https://web.archive.org/web/20150809075953/http://events.linuxfoundation.org:80/events/linuxcon-north-america>

--- a/2016/LinuxConNA.yml
+++ b/2016/LinuxConNA.yml
@@ -6,4 +6,4 @@ description: |
   There's simply no other event in North America where developers, sys admins, architects and all levels of technical talent gather together under one roof for education, collaboration and problem-solving to further the Linux platform.
 
   Additional details about the conference are available at
-  <http://events.linuxfoundation.org/events/linuxcon-north-america>.
+  <https://web.archive.org/web/20160806021814/http://events.linuxfoundation.org/events/linuxcon-north-america/>.


### PR DESCRIPTION
Past conferences website link is broken.
Pointing to the archved version of the event page instead.