### PR TITLE
Fix broken links to past 2016 events

### DIFF
--- a/2016/IncontroDevOpsItalia.yml
+++ b/2016/IncontroDevOpsItalia.yml
@@ -10,7 +10,7 @@ description: |
   enthusiasts.
 
   Additional details about the conference are available at
-  <http://www.incontrodevops.it/events/idi2016/>.
+  <https://web.archive.org/web/20160318174809/http://www.incontrodevops.it/events/idi2016/>.
 
 talks:
 

--- a/2016/LinuxConEU.yml
+++ b/2016/LinuxConEU.yml
@@ -7,4 +7,4 @@ description: |
   There's simply no other event in Europe where developers, sys admins, architects and all levels of technical talent gather together under one roof for education, collaboration and problem-solving to further the Linux platform.
 
   Additional details about the conference are available at
-  <http://events.linuxfoundation.org/events/linuxcon-europe>.
+  <https://web.archive.org/web/20160908213009/http://events.linuxfoundation.org/events/linuxcon-europe/>.


### PR DESCRIPTION
Using archived events page for IncontroDevOpsItalia and LinuxConEU
since the original page doesn't exist anymore.